### PR TITLE
Fix copy-pasta error in awesomebot configuration

### DIFF
--- a/.github/workflows/awesomebot.yml
+++ b/.github/workflows/awesomebot.yml
@@ -1,4 +1,4 @@
-name: Check links in ZSH list
+name: Check links in awesome-hangops
 
 on:
   push:


### PR DESCRIPTION
# Description

When I copied the awesomebot configuration from the [awesome-zsh-plugins](https://github.com/unixorn/awesome-zsh-plugins) repository, I forgot to change the name.

# Checklist:

<!---
Please put an `x` in the boxes to show your agreement.
-->

- [x] This document is covered by the [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License](https://github.com/hangops/awesome-hangops/blob/main/LICENSE), and I agree to contribute this pull request under the terms of the license.
- [x] I have confirmed that the link(s) in my PR are valid.
