### PR TITLE
Add section for chairs that regularly get recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Collected wisdom from the hangops slack.
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [awesome-hangops](#awesome-hangops)
-  - [Remote Setup](#remote-setup)
-    - [Desks](#desks)
+- [Remote Setup](#remote-setup)
+  - [Desks](#desks)
+  - [Chairs](#chairs)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -21,3 +21,10 @@ Collected wisdom from the hangops slack.
 
 - [Fully Jarvis](https://www.fully.com/standing-desks/jarvis.html) - Many hangops members swear by their Fully Jarvis sit/stand desks.
 - [VIVO](https://vivo-us.com/) - VIVO is a lower cost option than others but has a great product and an excellent support team. 
+
+### Chairs
+
+- [Herman Miller Aeron](https://www.hermanmiller.com/en_gb/products/seating/office-chairs/aeron-chairs/) - Nobody got fired for buying an Aeron
+- [Steelcase Leap](https://www.steelcase.com/products/office-chairs/leap/) - strong competitor in the same price range as the Aeron.
+
+**Note:** chairs can often be bought refurbished or second hand from office surplus/used furniture stores, sometimes for 50% or more off the price, so search around if you're on a budget. 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to -->
<!--- create a PR and ask. We're happy to help! -->

# Description

Adds a 'Chairs' section to the remote setup recommendations.

Note: `doctoc` appeared to regenerate the TOC slightly differently removing the top level heading in the list. No practical difference, but that's why it's changed, because `doctoc` did it.

# Checklist:

<!---
Please put an `x` in the boxes to show your agreement.
-->

- [x] This document is covered by the [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License](https://github.com/hangops/awesome-hangops/blob/main/LICENSE), and I agree to contribute this pull request under the terms of the license.
- [x] I have confirmed that the link(s) in my PR are valid.
