### PR TITLE
feat: add doctoc pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,8 @@ repos:
     hooks:
       - id: markdownlint-fix
         args: ["--ignore", "LICENSE.md"]
+  - repo: https://github.com/thlorenz/doctoc
+    rev: v2.2.0
+    hooks:
+      - id: doctoc
+        args: ["--update-only"]


### PR DESCRIPTION
# Description

Adds a `doctoc` check to the `pre-commit` config to ensure the TOC stays up to date.

# Checklist

- [x] This document is covered by the [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License](https://github.com/hangops/awesome-hangops/blob/main/LICENSE), and I agree to contribute this pull request under the terms of the license.
- [x] I have confirmed that the link(s) in my PR are valid.
